### PR TITLE
create database with UTF8 character set

### DIFF
--- a/start.bash
+++ b/start.bash
@@ -21,6 +21,6 @@ output "--- Executing TB_CONFIG/gen_tip.sh ---"
 $TB_CONFIG/gen_tip.sh
 
 output "--- Creating the Database with TB_HOME/bin/tb_create_db.sh ---"
-$TB_HOME/bin/tb_create_db.sh
+$TB_HOME/bin/tb_create_db.sh -ch UTF8
 
 fi


### PR DESCRIPTION
Default character set in tbctl script is "MSWIN949". 
Adding "-ch UTF8" to create_db will create database with UTF8 character set